### PR TITLE
Ability to disable KMS key auto rotation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,7 @@ module "cluster" {
   kms_keyring                                  = var.kms_keyring
   kms_crypto_key                               = var.kms_crypto_key
   kms_protection_level                         = var.kms_protection_level
+  kms_auto_rotate                              = var.kms_auto_rotate
   load_balancing_scheme                        = var.load_balancing_scheme
   vault_args                                   = var.vault_args
   vault_instance_labels                        = var.vault_instance_labels

--- a/modules/cluster/crypto.tf
+++ b/modules/cluster/crypto.tf
@@ -25,7 +25,7 @@ resource "google_kms_key_ring" "vault" {
 resource "google_kms_crypto_key" "vault-init" {
   name            = var.kms_crypto_key
   key_ring        = google_kms_key_ring.vault.id
-  rotation_period = "604800s"
+  rotation_period = var.kms_auto_rotate ? "604800s" : null
 
   version_template {
     algorithm        = "GOOGLE_SYMMETRIC_ENCRYPTION"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -121,7 +121,7 @@ variable "kms_auto_rotate" {
   type    = bool
   default = true
 
-  description = "Should KMS key be automatically rotated. Rotated every 7 days if set to false."
+  description = "Should KMS key be automatically rotated. Rotated every 7 days if set to true."
 }
 
 #TODO: Evaluate https://www.terraform.io/docs/configuration/variables.html#custom-validation-rules when prod ready

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -117,6 +117,12 @@ variable "kms_protection_level" {
   description = "The protection level to use for the KMS crypto key."
 }
 
+variable "kms_auto_rotate" {
+  type    = bool
+  default = true
+
+  description = "Should KMS key be automatically rotated. Rotated every 7 days if set to false."
+}
 
 #TODO: Evaluate https://www.terraform.io/docs/configuration/variables.html#custom-validation-rules when prod ready
 variable "load_balancing_scheme" {

--- a/variables.tf
+++ b/variables.tf
@@ -184,6 +184,13 @@ variable "kms_protection_level" {
   description = "The protection level to use for the KMS crypto key."
 }
 
+variable "kms_auto_rotate" {
+  type    = bool
+  default = true
+
+  description = "Should KMS key be automatically rotated. Rotated every 7 days if set to false."
+}
+
 #
 #
 # Networking

--- a/variables.tf
+++ b/variables.tf
@@ -188,7 +188,7 @@ variable "kms_auto_rotate" {
   type    = bool
   default = true
 
-  description = "Should KMS key be automatically rotated. Rotated every 7 days if set to false."
+  description = "Should KMS key be automatically rotated. Rotated every 7 days if set to true."
 }
 
 #


### PR DESCRIPTION
We want to be able to rotate the key manually to save the key externally, which may be necessary for compliance reasons.