### PR TITLE
Allow disablig auto KMS key version creation on init

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,7 @@ module "cluster" {
   kms_crypto_key                               = var.kms_crypto_key
   kms_protection_level                         = var.kms_protection_level
   kms_auto_rotate                              = var.kms_auto_rotate
+  kms_skip_initial_version_creation            = var.kms_skip_initial_version_creation
   load_balancing_scheme                        = var.load_balancing_scheme
   vault_args                                   = var.vault_args
   vault_instance_labels                        = var.vault_instance_labels

--- a/modules/cluster/crypto.tf
+++ b/modules/cluster/crypto.tf
@@ -23,9 +23,10 @@ resource "google_kms_key_ring" "vault" {
 
 # Create the crypto key for encrypting init keys
 resource "google_kms_crypto_key" "vault-init" {
-  name            = var.kms_crypto_key
-  key_ring        = google_kms_key_ring.vault.id
-  rotation_period = var.kms_auto_rotate ? "604800s" : null
+  name                          = var.kms_crypto_key
+  key_ring                      = google_kms_key_ring.vault.id
+  rotation_period               = var.kms_auto_rotate ? "604800s" : null
+  skip_initial_version_creation = var.kms_skip_initial_version_creation
 
   version_template {
     algorithm        = "GOOGLE_SYMMETRIC_ENCRYPTION"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -128,7 +128,7 @@ variable "kms_skip_initial_version_creation" {
   type    = bool
   default = false
 
-  description = "Should initial KMS key version be created."
+  description = "Should skip initial KMS key version creation."
 }
 
 #TODO: Evaluate https://www.terraform.io/docs/configuration/variables.html#custom-validation-rules when prod ready

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -124,6 +124,13 @@ variable "kms_auto_rotate" {
   description = "Should KMS key be automatically rotated. Rotated every 7 days if set to true."
 }
 
+variable "kms_skip_initial_version_creation" {
+  type    = bool
+  default = false
+
+  description = "Should initial KMS key version be created."
+}
+
 #TODO: Evaluate https://www.terraform.io/docs/configuration/variables.html#custom-validation-rules when prod ready
 variable "load_balancing_scheme" {
   type    = string

--- a/variables.tf
+++ b/variables.tf
@@ -190,6 +190,12 @@ variable "kms_auto_rotate" {
   description = "Should KMS key be automatically rotated. Rotated every 7 days if set to true."
 }
 
+variable "kms_skip_initial_version_creation" {
+  type    = bool
+  default = false
+
+  description = "Should initial KMS key version be created."
+}
 #
 #
 # Networking

--- a/variables.tf
+++ b/variables.tf
@@ -194,7 +194,7 @@ variable "kms_skip_initial_version_creation" {
   type    = bool
   default = false
 
-  description = "Should initial KMS key version be created."
+  description = "Should skip initial KMS key version creation."
 }
 #
 #


### PR DESCRIPTION
Chcemy pominąć generację pierwszego klucza, żeby wrzucić BYOKa i nim zainicjować auto-unseala. Trzeba będzie otagować: v6.2.4